### PR TITLE
fixes and code clean up of SDS.

### DIFF
--- a/livingatlas/configs/la-pipelines.yaml
+++ b/livingatlas/configs/la-pipelines.yaml
@@ -32,6 +32,9 @@ fs:
 alaNameMatch:
   wsUrl: http://localhost:9179
   timeoutSec: 70
+sds:
+  wsUrl: http://localhost:9189
+  timeoutSec: 70
 collectory:
   wsUrl: https://collections.ala.org.au
   timeoutSec: 70
@@ -132,6 +135,10 @@ sample-avro:
   ## For spark-embedded:
   # appName: SamplingToAvro indexing for {datasetId}
 
+sensitive:
+  inputPath: '{fsPath}/pipelines-data'
+  runner: SparkRunner
+
 # class: au.org.ala.pipelines.java.ALAInterpretedToSolrIndexPipeline
 index:
   inputPath: '{fsPath}/pipelines-data'
@@ -203,6 +210,16 @@ export-latlng-sh-args:
     jvm:
   spark-cluster:
     conf:
+    num-executors: 8
+    executor-cores: 8
+    executor-memory: 16G
+    driver-memory: 4G
+
+sensitive-sh-args:
+  spark-embedded:
+    jvm: -Xmx8g -XX:+UseG1GC
+  spark-cluster:
+    jvm: -Xmx8g -XX:+UseG1GC
     num-executors: 8
     executor-cores: 8
     executor-memory: 16G

--- a/livingatlas/pipelines/src/main/docker/ala-sensitive-data-service.yml
+++ b/livingatlas/pipelines/src/main/docker/ala-sensitive-data-service.yml
@@ -1,0 +1,9 @@
+version: "2.4"
+
+services:
+  ala-sensitive-data-service:
+    container_name: "ala-sensitive-data-service"
+    image: "charvolant/ala-sensitive-data-service:v20200214-2"
+    ports:
+      - "9190:9190"
+      - "9189:9189"

--- a/livingatlas/pipelines/src/main/java/au/org/ala/pipelines/beam/ALAInterpretedToSensitivePipeline.java
+++ b/livingatlas/pipelines/src/main/java/au/org/ala/pipelines/beam/ALAInterpretedToSensitivePipeline.java
@@ -4,21 +4,15 @@ import static org.gbif.pipelines.common.PipelinesVariables.Pipeline.AVRO_EXTENSI
 
 import au.org.ala.kvs.ALAPipelinesConfig;
 import au.org.ala.kvs.ALAPipelinesConfigFactory;
-import au.org.ala.kvs.cache.ALAAttributionKVStoreFactory;
 import au.org.ala.kvs.cache.SDSCheckKVStoreFactory;
 import au.org.ala.kvs.cache.SDSReportKVStoreFactory;
 import au.org.ala.kvs.client.SDSConservationServiceFactory;
-import au.org.ala.pipelines.common.ALARecordTypes;
-import au.org.ala.pipelines.transforms.ALASensitiveDataApplicationTransform;
 import au.org.ala.pipelines.transforms.ALASensitiveDataRecordTransform;
 import au.org.ala.pipelines.transforms.ALATaxonomyTransform;
-import au.org.ala.pipelines.transforms.ALAUUIDTransform;
 import au.org.ala.pipelines.util.VersionInfo;
 import au.org.ala.utils.ALAFsUtils;
 import au.org.ala.utils.CombinedYamlConfiguration;
 import java.io.IOException;
-import java.time.LocalDateTime;
-import java.time.ZoneOffset;
 import java.util.function.UnaryOperator;
 import lombok.AccessLevel;
 import lombok.NoArgsConstructor;
@@ -29,14 +23,12 @@ import org.apache.beam.sdk.transforms.join.CoGroupByKey;
 import org.apache.beam.sdk.transforms.join.KeyedPCollectionTuple;
 import org.apache.beam.sdk.values.KV;
 import org.apache.beam.sdk.values.PCollection;
-import org.gbif.pipelines.common.PipelinesVariables;
 import org.gbif.pipelines.common.beam.metrics.MetricsHandler;
 import org.gbif.pipelines.common.beam.options.InterpretationPipelineOptions;
 import org.gbif.pipelines.common.beam.options.PipelinesOptionsFactory;
 import org.gbif.pipelines.common.beam.utils.PathBuilder;
 import org.gbif.pipelines.io.avro.*;
 import org.gbif.pipelines.transforms.core.LocationTransform;
-import org.gbif.pipelines.transforms.core.TaxonomyTransform;
 import org.gbif.pipelines.transforms.core.TemporalTransform;
 import org.gbif.pipelines.transforms.core.VerbatimTransform;
 import org.slf4j.MDC;
@@ -45,7 +37,6 @@ import org.slf4j.MDC;
 @Slf4j
 @NoArgsConstructor(access = AccessLevel.PRIVATE)
 public class ALAInterpretedToSensitivePipeline {
-  public static final boolean USE_GBIF_TAXONOMY = false;
 
   public static void main(String[] args) throws IOException {
     VersionInfo.print();
@@ -56,12 +47,11 @@ public class ALAInterpretedToSensitivePipeline {
   }
 
   public static void run(InterpretationPipelineOptions options) throws IOException {
+
     ALAPipelinesConfig config =
         ALAPipelinesConfigFactory.getInstance(
                 options.getHdfsSiteConfig(), options.getCoreSiteConfig(), options.getProperties())
             .get();
-
-    String id = Long.toString(LocalDateTime.now().toEpochSecond(ZoneOffset.UTC));
 
     MDC.put("datasetId", options.getDatasetId());
     MDC.put("attempt", options.getAttempt().toString());
@@ -71,9 +61,7 @@ public class ALAInterpretedToSensitivePipeline {
     UnaryOperator<String> inputPathFn =
         t -> PathBuilder.buildPathInterpretUsingTargetPath(options, t, "*" + AVRO_EXTENSION);
     UnaryOperator<String> outputPathFn =
-        t -> ALAFsUtils.buildPathGeneralisedUsingTargetPath(options, t, id);
-    UnaryOperator<String> identifiersPathFn =
-        t -> ALAFsUtils.buildPathIdentifiersUsingTargetPath(options, t, "*" + AVRO_EXTENSION);
+        t -> ALAFsUtils.buildPathGeneralisedUsingTargetPath(options, t);
 
     Pipeline p = Pipeline.create(options);
 
@@ -82,67 +70,21 @@ public class ALAInterpretedToSensitivePipeline {
     VerbatimTransform verbatimTransform = VerbatimTransform.create();
     TemporalTransform temporalTransform = TemporalTransform.builder().create();
     LocationTransform locationTransform = LocationTransform.builder().create();
-    TaxonomyTransform taxonomyTransform = TaxonomyTransform.builder().create();
 
     // ALA specific
-    ALAUUIDTransform alaUuidTransform = ALAUUIDTransform.create();
     ALATaxonomyTransform alaTaxonomyTransform = ALATaxonomyTransform.builder().create();
     ALASensitiveDataRecordTransform alaSensitiveDataRecordTransform =
         ALASensitiveDataRecordTransform.builder()
             .datasetId(options.getDatasetId())
             .speciesStoreSupplier(SDSCheckKVStoreFactory.getInstanceSupplier(config))
             .reportStoreSupplier(SDSReportKVStoreFactory.getInstanceSupplier(config))
-            .dataResourceStoreSupplier(ALAAttributionKVStoreFactory.getInstanceSupplier(config))
             .conservationServiceSupplier(SDSConservationServiceFactory.getInstanceSupplier(config))
             .erTag(verbatimTransform.getTag())
             .trTag(temporalTransform.getTag())
             .lrTag(locationTransform.getTag())
-            .txrTag(USE_GBIF_TAXONOMY ? taxonomyTransform.getTag() : null)
+            .txrTag(null)
             .atxrTag(alaTaxonomyTransform.getTag())
             .create();
-    ALASensitiveDataApplicationTransform<ExtendedRecord> alaSensitiveErTransform =
-        new ALASensitiveDataApplicationTransform<>(
-            ExtendedRecord.class,
-            PipelinesVariables.Pipeline.Interpretation.RecordType.VERBATIM,
-            null,
-            SDSConservationServiceFactory.getInstanceSupplier(config),
-            verbatimTransform.getTag(),
-            alaSensitiveDataRecordTransform.getTag());
-    ALASensitiveDataApplicationTransform<TemporalRecord> alaSensitiveTrTransform =
-        new ALASensitiveDataApplicationTransform<>(
-            TemporalRecord.class,
-            PipelinesVariables.Pipeline.Interpretation.RecordType.TEMPORAL,
-            null,
-            SDSConservationServiceFactory.getInstanceSupplier(config),
-            temporalTransform.getTag(),
-            alaSensitiveDataRecordTransform.getTag());
-    ALASensitiveDataApplicationTransform<LocationRecord> alaSensitiveLrTransform =
-        new ALASensitiveDataApplicationTransform<>(
-            LocationRecord.class,
-            PipelinesVariables.Pipeline.Interpretation.RecordType.LOCATION,
-            null,
-            SDSConservationServiceFactory.getInstanceSupplier(config),
-            locationTransform.getTag(),
-            alaSensitiveDataRecordTransform.getTag());
-    ALASensitiveDataApplicationTransform<TaxonRecord> alaSensitiveTxrTransform = null;
-    if (USE_GBIF_TAXONOMY) {
-      alaSensitiveTxrTransform =
-          new ALASensitiveDataApplicationTransform<>(
-              TaxonRecord.class,
-              PipelinesVariables.Pipeline.Interpretation.RecordType.TAXONOMY,
-              null,
-              SDSConservationServiceFactory.getInstanceSupplier(config),
-              taxonomyTransform.getTag(),
-              alaSensitiveDataRecordTransform.getTag());
-    }
-    ALASensitiveDataApplicationTransform<ALATaxonRecord> alaSensitiveAtxrTransform =
-        new ALASensitiveDataApplicationTransform<>(
-            ALATaxonRecord.class,
-            ALARecordTypes.ALA_TAXONOMY,
-            null,
-            SDSConservationServiceFactory.getInstanceSupplier(config),
-            alaTaxonomyTransform.getTag(),
-            alaSensitiveDataRecordTransform.getTag());
 
     log.info("Adding step 3: Creating beam pipeline");
     PCollection<KV<String, ExtendedRecord>> inputVerbatimCollection =
@@ -157,18 +99,6 @@ public class ALAInterpretedToSensitivePipeline {
         p.apply("Read Location", locationTransform.read(inputPathFn))
             .apply("Map Location to KV", locationTransform.toKv());
 
-    PCollection<KV<String, TaxonRecord>> inputTaxonCollection = null;
-    if (USE_GBIF_TAXONOMY) {
-      inputTaxonCollection =
-          p.apply("Read Location", taxonomyTransform.read(inputPathFn))
-              .apply("Map Location to KV", taxonomyTransform.toKv());
-    }
-
-    // ALA Specific
-    PCollection<KV<String, ALAUUIDRecord>> inputAlaUUidCollection =
-        p.apply("Read Taxon", alaUuidTransform.read(identifiersPathFn))
-            .apply("Map Taxon to KV", alaUuidTransform.toKv());
-
     PCollection<KV<String, ALATaxonRecord>> inputAlaTaxonCollection =
         p.apply("Read Taxon", alaTaxonomyTransform.read(inputPathFn))
             .apply("Map Taxon to KV", alaTaxonomyTransform.toKv());
@@ -180,51 +110,13 @@ public class ALAInterpretedToSensitivePipeline {
             .and(temporalTransform.getTag(), inputTemporalCollection)
             .and(locationTransform.getTag(), inputLocationCollection)
             // ALA Specific
-            .and(alaUuidTransform.getTag(), inputAlaUUidCollection)
             .and(alaTaxonomyTransform.getTag(), inputAlaTaxonCollection);
-    if (USE_GBIF_TAXONOMY)
-      inputTuples = inputTuples.and(taxonomyTransform.getTag(), inputTaxonCollection);
 
     log.info("Creating sensitivity records");
-    PCollection<ALASensitivityRecord> sensitivityRecords =
-        inputTuples
-            .apply("Grouping objects", CoGroupByKey.create())
-            .apply("Converting to sensitvity records", alaSensitiveDataRecordTransform.interpret());
-
-    log.info("Writing sensitivity records");
-    sensitivityRecords.apply(alaSensitiveDataRecordTransform.write(outputPathFn));
-
-    log.info("Generalising other records");
-    PCollection<KV<String, ALASensitivityRecord>> sensitivityCollection =
-        sensitivityRecords.apply(alaSensitiveDataRecordTransform.toKv());
-
-    KeyedPCollectionTuple.of(verbatimTransform.getTag(), inputVerbatimCollection)
-        .and(alaSensitiveDataRecordTransform.getTag(), sensitivityCollection)
-        .apply(CoGroupByKey.create())
-        .apply("Generalising extended records", alaSensitiveErTransform.interpret())
-        .apply(alaSensitiveErTransform.write(outputPathFn).withoutSharding());
-    KeyedPCollectionTuple.of(temporalTransform.getTag(), inputTemporalCollection)
-        .and(alaSensitiveDataRecordTransform.getTag(), sensitivityCollection)
-        .apply(CoGroupByKey.create())
-        .apply("Generalising temporal records", alaSensitiveTrTransform.interpret())
-        .apply(alaSensitiveTrTransform.write(outputPathFn).withoutSharding());
-    KeyedPCollectionTuple.of(locationTransform.getTag(), inputLocationCollection)
-        .and(alaSensitiveDataRecordTransform.getTag(), sensitivityCollection)
-        .apply(CoGroupByKey.create())
-        .apply("Generalising location records", alaSensitiveLrTransform.interpret())
-        .apply(alaSensitiveLrTransform.write(outputPathFn).withoutSharding());
-    if (USE_GBIF_TAXONOMY) {
-      KeyedPCollectionTuple.of(taxonomyTransform.getTag(), inputTaxonCollection)
-          .and(alaSensitiveDataRecordTransform.getTag(), sensitivityCollection)
-          .apply(CoGroupByKey.create())
-          .apply("Generalising taxonomy records", alaSensitiveTxrTransform.interpret())
-          .apply(alaSensitiveTxrTransform.write(outputPathFn).withoutSharding());
-    }
-    KeyedPCollectionTuple.of(alaTaxonomyTransform.getTag(), inputAlaTaxonCollection)
-        .and(alaSensitiveDataRecordTransform.getTag(), sensitivityCollection)
-        .apply(CoGroupByKey.create())
-        .apply("Generalising ALA taxonomy records", alaSensitiveAtxrTransform.interpret())
-        .apply(alaSensitiveAtxrTransform.write(outputPathFn).withoutSharding());
+    inputTuples
+        .apply("Grouping objects", CoGroupByKey.create())
+        .apply("Converting to sensitivity records", alaSensitiveDataRecordTransform.interpret())
+        .apply("Write to AVRO", alaSensitiveDataRecordTransform.write(outputPathFn));
 
     log.info("Running the pipeline");
     PipelineResult result = p.run();

--- a/livingatlas/pipelines/src/main/java/au/org/ala/utils/ALAFsUtils.java
+++ b/livingatlas/pipelines/src/main/java/au/org/ala/utils/ALAFsUtils.java
@@ -51,11 +51,9 @@ public class ALAFsUtils {
    * 'ala_sensitive_taxon'
    */
   public static String buildPathGeneralisedUsingTargetPath(
-      BasePipelineOptions options, String name, String uniqueId) {
+      BasePipelineOptions options, String name) {
     return PathBuilder.buildPath(
-            PathBuilder.buildDatasetAttemptPath(options, "generalised", false),
-            name,
-            "generalise-" + uniqueId)
+            PathBuilder.buildDatasetAttemptPath(options, "generalised", false), name, "generalise")
         .toString();
   }
 

--- a/livingatlas/pipelines/src/test/java/au/org/ala/pipelines/interpreters/SensitiveDataInterpreterTest.java
+++ b/livingatlas/pipelines/src/test/java/au/org/ala/pipelines/interpreters/SensitiveDataInterpreterTest.java
@@ -474,7 +474,7 @@ public class SensitiveDataInterpreterTest {
     ExtendedRecord er = ExtendedRecord.newBuilder().setId("1").setCoreTerms(map).build();
     Map<String, String> properties = new HashMap<>();
     SensitiveDataInterpreter.constructFields(this.sensitive, properties, er);
-    SensitiveDataInterpreter.sourceQualityChecks(properties, sr, this.dataResource);
+    SensitiveDataInterpreter.sourceQualityChecks(properties, sr);
     assertTrue(sr.getIssues().getIssueList().isEmpty());
   }
 
@@ -490,7 +490,7 @@ public class SensitiveDataInterpreterTest {
     ExtendedRecord er = ExtendedRecord.newBuilder().setId("1").setCoreTerms(map).build();
     Map<String, String> properties = new HashMap<>();
     SensitiveDataInterpreter.constructFields(this.sensitive, properties, er);
-    SensitiveDataInterpreter.sourceQualityChecks(properties, sr, this.dataResource);
+    SensitiveDataInterpreter.sourceQualityChecks(properties, sr);
     assertFalse(sr.getIssues().getIssueList().isEmpty());
     assertTrue(
         sr.getIssues().getIssueList().contains(ALAOccurrenceIssue.NAME_NOT_SUPPLIED.getId()));
@@ -511,11 +511,10 @@ public class SensitiveDataInterpreterTest {
     Map<String, String> properties = new HashMap<>();
     SensitiveDataInterpreter.constructFields(this.sensitive, properties, er);
     SensitiveDataInterpreter.sensitiveDataInterpreter(
-        dataResource,
         this.sensitivityLookup,
         this.sensitivityReportLookup,
         this.generalisations,
-        this.dataResource.getUid(),
+        "dr1",
         properties,
         sr);
     assertTrue(sr.getIssues().getIssueList().isEmpty());

--- a/livingatlas/scripts/la-pipelines
+++ b/livingatlas/scripts/la-pipelines
@@ -55,6 +55,7 @@ dwca-avro --> interpret --> uuid -->                │
 -  'sample' crawl the LA layers. Requires an input csv containing lat, lng (no header) and output directory.
 -  'sample-avro' adds a sampling AVRO extension to the stored interpretation
 -  'index' reads a Dwc-A, interprets it and index the interpeted data creating a SOLR index.
+-  'sds' reads a Dwc-A, interprets it and index the interpeted data creating a SOLR index.
 -  'archive-list' dumps out a list of archives that can be ingested to '/tmp/dataset-archive-list.csv'
 -  'dataset-list' dumps out a list of datasets that have been ingested to '/tmp/dataset-counts.csv'
 -  'validation-report' dumps out a CSV list of datasets ready to be indexed to '/tmp/validation-report.csv'
@@ -69,6 +70,7 @@ Usage:
   $CMD [options] export-latlng (<dr>...|all)         $WHERE
   $CMD [options] sample        (<dr>...|all)
   $CMD [options] sample-avro   (<dr>...|all)         $WHERE
+  $CMD [options] sds           (<dr>...|all)         $WHERE
   $CMD [options] index         (<dr>...|all) $WHEREL
   $CMD [options] archive-list
   $CMD [options] dataset-list
@@ -486,6 +488,27 @@ function sample-avro () {
     logStepEnd "Sample-avro" $dr $ltype $SECONDS
 }
 
+function sds () {
+    local dr="$1" ltype="$2"
+
+    logStepStart "SDS" $dr
+    SECONDS=0
+
+    SH_ARGS=index-sh-args.local
+    CLASS=au.org.ala.pipelines.beam.ALAInterpretedToSensitivePipeline
+    java-pipeline $ltype $SH_ARGS $CLASS $dr
+
+    SH_ARGS=index-sh-args.spark-embedded
+    CLASS=au.org.ala.pipelines.beam.ALAInterpretedToSensitivePipeline
+    spark-embed-pipeline $ltype $SH_ARGS $CLASS $dr
+
+    SH_ARGS=index-sh-args.spark-cluster
+    CLASS=au.org.ala.pipelines.beam.ALAInterpretedToSensitivePipeline
+    spark-cluster-pipeline $ltype $SH_ARGS $CLASS $dr "SDS for $dr"
+
+    logStepEnd "SDS" $dr $ltype $SECONDS
+}
+
 function index () {
     local dr="$1" ltype="$2"
 
@@ -592,6 +615,10 @@ fi
 
 if ($index || $do_all); then
     do_step index
+fi
+
+if ($sds || $do_all); then
+    do_step sds
 fi
 
 # All ended correctly, so untrap EXIT catch


### PR DESCRIPTION
Changed the SDS pipeline to only produce the ALASensitivityRecord output.
Added the SparkRunner in the YAML config (default is DirectRunner which only useful for testing)
Removed the references to GBIF taxonomy as this is currently not a realistic option due to performance issues with using GBIF webservices remotely without the aid of persistent KV caches